### PR TITLE
Fix: intrinsict attribute error

### DIFF
--- a/src/app/components/AuthLayout/AuthLayout.tsx
+++ b/src/app/components/AuthLayout/AuthLayout.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { updateUser } from "src/features/user/userSlice";
@@ -6,7 +6,11 @@ import { useAppDispatch } from "src/hooks";
 import { IUser } from "src/interfaces/IUser.interface";
 import { AuthService } from "src/services/auth.service";
 
-export const AuthLayout: FC = ({ children }) => {
+interface Props {
+	children: React.ReactNode,
+};
+
+export const AuthLayout = (props: Props) => {
 	const dispatch = useAppDispatch();
 	const [fetchedUser, setFetchedUser] = useState<boolean>(false);
 	const history = useNavigate();
@@ -28,7 +32,7 @@ export const AuthLayout: FC = ({ children }) => {
 		<div id='auth-layout'>
 			{
 				fetchedUser &&
-				children
+				props.children
 			}
 		</div>
 	)

--- a/src/app/components/Layout/Layout.tsx
+++ b/src/app/components/Layout/Layout.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect } from "react"
+import { useEffect } from "react"
 import { updateUser } from "src/features/user/userSlice";
 import { useAppDispatch } from "src/hooks";
 import { IUser } from "src/interfaces/IUser.interface";
@@ -8,7 +8,11 @@ import { Menubar } from "../Menubar/Menubar"
 
 import "./scss/Layout.scss";
 
-export const Layout: FC = ({ children }) => {
+interface Props {
+	children: React.ReactNode,
+};
+
+export const Layout = (props: Props) => {
 	const dispatch = useAppDispatch();
 
 	useEffect(() => {
@@ -24,7 +28,7 @@ export const Layout: FC = ({ children }) => {
 	return (
 		<div id='layout' className='column'>
 			<Menubar />
-			<main>{children}</main>
+			<main>{props.children}</main>
 			<FooterComponent />
 		</div>
 	)


### PR DESCRIPTION
Fixing `TS2559: Type '{ children: Element; }' has no properties in common with type 'IntrinsicAttributes'.` due to React Router v6 and children being passed without being encapsulated in Props.