### PR TITLE
fix: update publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,11 +8,13 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  REACT_APP_API_URI: api.beauf.net
+  API_URI: https://api.beauf.net
+  API_URI_STAGING: https://staging.api.beauf.net
 
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
+    environment: main
     permissions:
       contents: read
       packages: write
@@ -53,3 +55,4 @@ jobs:
           push: true
           tags: ${{ steps.docker_metadata.outputs.tags }}
           labels: ${{ steps.docker_metadata.outputs.labels }}
+          build-args: REACT_APP_API_URI=${{ steps.docker_metadata.outputs.labels.org.opencontainers.image.version == 'nightly' && env.API_URI_STAGING || env.API_URI }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,6 @@ COPY . ./
 
 RUN yarn build
 
-
-
 FROM nginx:stable-alpine AS runner
 
 WORKDIR /usr/share/nginx/html
@@ -25,9 +23,9 @@ WORKDIR /usr/share/nginx/html
 RUN rm -rf ./* &&\
  	rm /etc/nginx/conf.d/default.conf
 
-COPY nginx.conf /etc/nginx/conf.d
+COPY --chown=nginx:nginx nginx.conf /etc/nginx/conf.d
 
-COPY --from=builder /app/build .
+COPY --from=builder --chown=nginx:nginx /app/build .
 
 EXPOSE 80
 


### PR DESCRIPTION
App is taking `https://beta.beauf.net` as API URI instead of `https://staging.api.beauf.net`